### PR TITLE
[PF-2145] Null enhancements

### DIFF
--- a/service/src/main/java/bio/terra/user/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/user/db/ProfileDao.java
@@ -42,7 +42,7 @@ public class ProfileDao {
     final String sql =
         """
         UPDATE user_profile
-        SET profile_obj = pathRecurse(profile_obj, :path::text[], :value::jsonb)
+        SET profile_obj = jsonb_strip_nulls(pathRecurse(profile_obj, :path::text[], :value::jsonb))
         WHERE user_id = :user_id
         """;
 

--- a/service/src/main/java/bio/terra/user/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/user/db/ProfileDao.java
@@ -10,6 +10,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
 @Component
 public class ProfileDao {
@@ -85,7 +86,7 @@ public class ProfileDao {
             return rs.getString("value");
           });
     } catch (EmptyResultDataAccessException e) {
-      return "{}";
+      return CollectionUtils.isEmpty(path) ? "{}" : null;
     }
   }
 

--- a/service/src/main/java/bio/terra/user/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/user/db/ProfileDao.java
@@ -4,6 +4,7 @@ import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
 import bio.terra.user.db.exception.BadPathException;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -61,10 +62,12 @@ public class ProfileDao {
   }
 
   @ReadTransaction
+  @Nullable
   public String getProperty(String userId, List<String> path) {
     return getPropertySingle(userId, path);
   }
 
+  @Nullable
   private String getPropertySingle(String userId, List<String> path) {
     final String sql =
         """

--- a/service/src/main/java/bio/terra/user/db/ProfileDao.java
+++ b/service/src/main/java/bio/terra/user/db/ProfileDao.java
@@ -64,11 +64,6 @@ public class ProfileDao {
   @ReadTransaction
   @Nullable
   public String getProperty(String userId, List<String> path) {
-    return getPropertySingle(userId, path);
-  }
-
-  @Nullable
-  private String getPropertySingle(String userId, List<String> path) {
     final String sql =
         """
         SELECT profile_obj #> :path::text[] AS value
@@ -89,6 +84,10 @@ public class ProfileDao {
             return rs.getString("value");
           });
     } catch (EmptyResultDataAccessException e) {
+      // If the row for the user doesn't exist yet, we try and
+      // keep the behaviour consistent to the client by pretending
+      // the profile object is empty and/or the specific path requested
+      // does not exist.
       return CollectionUtils.isEmpty(path) ? "{}" : null;
     }
   }

--- a/service/src/main/java/bio/terra/user/service/user/ProfileService.java
+++ b/service/src/main/java/bio/terra/user/service/user/ProfileService.java
@@ -8,6 +8,7 @@ import bio.terra.user.service.exception.MalformedPropertyException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -45,7 +46,7 @@ public class ProfileService {
     var userId = user.getSubjectId();
 
     var prop = profileDao.getProperty(userId, path);
-    if (prop == null) return null;
+    if (prop == null) return NullNode.getInstance();
 
     try {
       return objectMapper.readValue(prop, JsonNode.class);

--- a/service/src/test/java/bio/terra/user/app/controller/ProfileApiControllerTest.java
+++ b/service/src/test/java/bio/terra/user/app/controller/ProfileApiControllerTest.java
@@ -37,12 +37,20 @@ class ProfileApiControllerTest extends BaseUnitTest {
   @Test
   void getEmptyProfile() throws Exception {
     assertUserProfile("$.value", "");
+    assertUserProfile("fake", "$.value", null);
   }
 
   @Test
   void setProperty() throws Exception {
     setUserProfile("user.name.first", "{ \"value\": \"John\" }");
     assertUserProfile("$.value.user.name.first", "John");
+  }
+
+  @Test
+  void nonEmptyProfileNoValue() throws Exception {
+    // row for the user now exists
+    setUserProfile("user", "{ \"value\": \"v\" }");
+    assertUserProfile("fake", "$.value", null);
   }
 
   @Test
@@ -71,8 +79,12 @@ class ProfileApiControllerTest extends BaseUnitTest {
   }
 
   private void assertUserProfile(String jsonPath, Object value) throws Exception {
+    assertUserProfile(null, jsonPath, value);
+  }
+
+  private void assertUserProfile(String apiPath, String jsonPath, Object value) throws Exception {
     mockMvc
-        .perform(get(API))
+        .perform(get(API).param("path", apiPath))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath(jsonPath).value(value));

--- a/service/src/test/java/bio/terra/user/db/ProfileDaoTest.java
+++ b/service/src/test/java/bio/terra/user/db/ProfileDaoTest.java
@@ -16,7 +16,15 @@ public class ProfileDaoTest extends BaseUnitTest {
   @Test
   void getEmptyProfile() throws Exception {
     var userId = TestUtils.appendRandomNumber("fake");
-    assertEquals(profileDao.getProperty(userId, List.of()), "{}");
+    assertEquals("{}", profileDao.getProperty(userId, List.of()));
+    assertEquals(null, profileDao.getProperty(userId, List.of("fake")));
+  }
+
+  @Test
+  void nonEmptyProfileNovalue() throws Exception {
+    var userId = TestUtils.appendRandomNumber("fake");
+    profileDao.setProperty(userId, List.of("user"), "\"v\"");
+    assertEquals(null, profileDao.getProperty(userId, List.of("fake")));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/user/db/ProfileDaoTest.java
+++ b/service/src/test/java/bio/terra/user/db/ProfileDaoTest.java
@@ -49,7 +49,7 @@ public class ProfileDaoTest extends BaseUnitTest {
     assertEquals(workspaces, profileDao.getProperty(userId, path));
 
     profileDao.setProperty(userId, path, "null");
-    assertEquals("null", profileDao.getProperty(userId, path));
+    assertEquals(null, profileDao.getProperty(userId, path));
   }
 
   @Test


### PR DESCRIPTION
Using java's null as the value in the response resulted in spring thinking the value was unset, so replacing that with an explicit json null.

Also, nulls are stripped when setting in the db to act more like a real delete operation when setting a property to null.