### PR TITLE
[PF-2478] Only run checks when PR targets default branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,12 +2,12 @@ name: Build and Test
 
 on:
   workflow_dispatch: {}
-
-  pull_request:
-    branches: [ '**' ]
-
   push:
-    branches: [ 'main' ]
+    branches: [ main ]
+    paths-ignore: [ '*.md' ]
+  pull_request:
+    # Branch settings require status checks before merging, so don't add paths-ignore.
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Only run PR checks when the PR targets primary/default branch

currently, all PRs (irrespective of the branch they target) automatically trigger PR checks. This is unnecessary and may cause the checks to be queued up on GitHub runner.

ref - 
- https://github.com/DataBiosphere/terra-workspace-manager/pull/1061
- https://broadworkbench.atlassian.net/browse/PF-2478