### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,7 +78,7 @@ jobs:
       run: ./gradlew --build-cache :service:test --scan
     - name: Upload Test Reports
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: Test Reports
         path: ./service/build/reports/tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,4 +85,4 @@ jobs:
     - name: Get current date
       id: date
       if: failure() && contains(github.actor, 'verily-automation-bot')
-      run: echo "::set-output name=date::$(TZ=America/New_York date +"%-m/%-d")"
+      run: echo date=$(TZ=America/New_York date +"%-m/%-d") >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
     - name: Gradle cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -60,7 +60,7 @@ jobs:
         distribution: 'temurin'
 
     - name: Gradle cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Set up JDK 17
@@ -50,7 +50,7 @@ jobs:
         ports: [ "5432:5432" ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Set up JDK 17

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         submodules: true
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -54,7 +54,7 @@ jobs:
       with:
         submodules: true
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,7 +78,7 @@ jobs:
       run: ./gradlew --build-cache :service:test --scan
     - name: Upload Test Reports
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Test Reports
         path: ./service/build/reports/tests


### PR DESCRIPTION
Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- use actions/cache@v3 instead of v2
- use actions/upload-artifact@v3 instead of v2
- use setup-node@v3 instead of v2
- replace 'set-output' command