### PR TITLE
[TERRA-492] Use latest bumper version

### DIFF
--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -50,7 +50,7 @@ jobs:
         token: ${{ secrets.BROADBOT_TOKEN }}
   
     - name: Bump the tag to a new version
-      uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
+      uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
       id: tag
       env:
         DEFAULT_BUMP: minor


### PR DESCRIPTION
[TERRA-492] Use latest bumper version - fixes github set-output deprecated warnings